### PR TITLE
Use Sharded Counters for Performance Monitoring

### DIFF
--- a/include/sync0sync.h
+++ b/include/sync0sync.h
@@ -36,6 +36,7 @@ Created 9/5/1995 Heikki Tuuri
 #include "os0thread.h"
 #include "sync0arr.h"
 #include "sync0mutex.h"
+#include "ut0counter.h"
 #include "ut0mem.h"
 
 /** Initializes the synchronization data structures. */
@@ -53,7 +54,7 @@ necessary only if the memory block containing it is freed. */
 location (which must be appropriately aligned). The mutex is initialized
 in the reset state. Explicit freeing of the mutex with mutex_free is
 necessary only if the memory block containing it is freed. */
-void mutex_create(mutex_t *mutex, IF_DEBUG(const char *cmutex_name,) IF_SYNC_DEBUG(ulint level,) Source_location loc);
+void mutex_create(mutex_t *mutex, IF_DEBUG(const char *cmutex_name, ) IF_SYNC_DEBUG(ulint level, ) Source_location loc);
 
 /** Calling this function is obligatory only if the memory buffer containing
 the mutex is freed. Removes a mutex object from the mutex list. The mutex
@@ -390,7 +391,9 @@ to 20 microseconds. */
 #define SYNC_SPIN_ROUNDS srv_n_spin_wait_rounds
 
 /** The number of mutex_exit calls. Intended for performance monitoring. */
-extern int64_t mutex_exit_count;
+// FIXME(RAHUL): Figure out the number of cpus.
+using counter_t = Sharded_counter<16>;
+extern counter_t mutex_exit_count;
 
 #ifdef UNIV_SYNC_DEBUG
 /** Latching order checks start when this is set true */

--- a/include/sync0sync.h
+++ b/include/sync0sync.h
@@ -392,7 +392,7 @@ to 20 microseconds. */
 
 /** The number of mutex_exit calls. Intended for performance monitoring. */
 // FIXME(RAHUL): Figure out the number of cpus.
-using counter_t = Sharded_counter<16>;
+using counter_t = ut::Sharded_counter<16>;
 extern counter_t mutex_exit_count;
 
 #ifdef UNIV_SYNC_DEBUG

--- a/include/ut0counter.h
+++ b/include/ut0counter.h
@@ -114,7 +114,7 @@ struct Counters {
   }
 
   void inc(Int value = 1) {
-    const auto index = m_indexer.get_index() % m_counters.size();
+    const auto index = m_indexer.get_index() % Shards;
 
     m_counters[index].get_ref().fetch_add(value, std::memory_order_relaxed);
   }

--- a/sync/sync0sync.cc
+++ b/sync/sync0sync.cc
@@ -228,10 +228,10 @@ struct sync_level_struct {
 };
 
 void sync_var_init() {
-  mutex_spin_round_count.reset();
-  mutex_spin_wait_count.reset();
-  mutex_os_wait_count.reset();
-  mutex_exit_count.reset();
+  mutex_spin_round_count.clear();
+  mutex_spin_wait_count.clear();
+  mutex_os_wait_count.clear();
+  mutex_exit_count.clear();
   sync_primary_wait_array = nullptr;
   sync_initialized = false;
 


### PR DESCRIPTION
**Background**: Replace the use of Performance Monitoring counters with sharded counters. 
Replaced the usage in `sync/sync0sync.cc`