### PR TITLE
[1/n]: Replace custom hash map with std::unordered_map in dict_sys

### DIFF
--- a/fil/fil0fil.cc
+++ b/fil/fil0fil.cc
@@ -30,7 +30,6 @@ Created 10/25/1995 Heikki Tuuri
 #include "dict0dict.h"
 #include "fil0fil.h"
 #include "fsp0fsp.h"
-#include "hash0hash.h"
 #include "log0recv.h"
 #include "mach0data.h"
 #include "mem0mem.h"

--- a/include/dict0types.h
+++ b/include/dict0types.h
@@ -27,11 +27,10 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "innodb0types.h"
 
-#include <string>
+#include <string_view>
 #include <unordered_map>
 #include "data0types.h"
 #include "fsp0types.h"
-#include "hash0hash.h"
 #include "lock0types.h"
 #include "mem0types.h"
 #include "rem0types.h"
@@ -454,12 +453,6 @@ struct dict_table_t {
   The final string will be allocated from table->heap. */
   const char *col_names;
 
-  /** Hash chain node */
-  hash_node_t name_hash;
-
-  /** Hash chain node */
-  hash_node_t id_hash;
-
   /** List of indexes of the table */
   UT_LIST_BASE_NODE_T(dict_index_t, indexes) indexes;
 
@@ -541,7 +534,7 @@ struct dict_sys_t {
   uint64_t row_id;
 
   /** Hash table of the tables, based on name */
-  std::unordered_map<std::string, dict_table_t *> *table_hash;
+  std::unordered_map<std::string_view, dict_table_t *> *table_hash;
 
   /** Hash table of the tables, based on id */
   std::unordered_map<std::uint64_t, dict_table_t *> *table_id_hash;

--- a/include/dict0types.h
+++ b/include/dict0types.h
@@ -27,6 +27,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "innodb0types.h"
 
+#include <string>
+#include <unordered_map>
 #include "data0types.h"
 #include "fsp0types.h"
 #include "hash0hash.h"
@@ -50,10 +52,10 @@ struct ind_node_t;
 struct tab_node_t;
 
 /** Space id and page no where the dictionary header resides */
-constexpr ulint DICT_HDR_SPACE  = 0;
+constexpr ulint DICT_HDR_SPACE = 0;
 
- /** The page number of the dictionary header */
-constexpr ulint DICT_HDR_PAGE_NO  = FSP_DICT_HDR_PAGE_NO;
+/** The page number of the dictionary header */
+constexpr ulint DICT_HDR_PAGE_NO = FSP_DICT_HDR_PAGE_NO;
 
 /** The flags for ON_UPDATE and ON_DELETE can be ORed; the default is that
 a foreign key constraint is enforced, therefore RESTRICT just means no flag */
@@ -539,10 +541,10 @@ struct dict_sys_t {
   uint64_t row_id;
 
   /** Hash table of the tables, based on name */
-  hash_table_t *table_hash;
+  std::unordered_map<std::string, dict_table_t *> *table_hash;
 
   /** Hash table of the tables, based on id */
-  hash_table_t *table_id_hash;
+  std::unordered_map<std::uint64_t, dict_table_t *> *table_id_hash;
 
   /** LRU list of tables */
   UT_LIST_BASE_NODE_T(dict_table_t, table_LRU) table_LRU;


### PR DESCRIPTION
Replace usage in `dict0dict.h`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dictionary management system with improved caching and indexing using modern C++ standard library features.
	- Streamlined search logic for table entries, resulting in faster lookups and easier maintenance.

- **Bug Fixes**
	- Improved error handling for duplicate table names and IDs.

- **Chores**
	- Removed unused header file references to simplify codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->