### PR TITLE
gitignore and FlexLexer.h search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,129 @@
+# Build directories
+cmake-build-*/
+install
+bin
+*.d
+*.o
+*.o[ls]
+*.obj
+*.so
+*.dylib
+*.dll
+*.exe
+*.a
+*.lib
+ib0config.h
+
+# CMake
+.cmake
+cmake_install.cmake
+CMakeCache.txt
+CMakeFiles/
+CMakeScripts/
+
+# IDE - CLion
+.idea/
+*.iml
+*.iws
+*.ipr
+
+# IDE - VSCode
+.vscode/
+*.code-workspace
+.history/
+
+# IDE - Neovim
+.nvimrc
+.vim/
+.nvim/
+*.swp
+*.swo
+Session.vim
+.netrwhist
+
+# IDE - Emacs
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Operating System
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs and databases
+*.log
+*.db
+
+# Generated files
+*.generated.*
+*_generated.h
+*_generated.cpp
+
+# Backup files
+*.bak
+*.backup
+*.tmp
+*.temp
+
+# Specific tool files
+compile_flags.txt
+.clangd/
+.cache/
+.ccls-cache/
+
+# Ninja build system
+.ninja_deps
+.ninja_log
+build.ninja
+
+# Valgrind
+callgrind.out.*
+cachegrind.out.*
+massif.out.*
+
+*.rej
+*.orig
+/*.patch
+
+/src/liburing.a
+/src/liburing.so*
+/src/liburing-ffi.a
+/src/liburing-ffi.so*
+/src/include/liburing/compat.h
+/src/include/liburing/io_uring_version.h
+
+/examples/io_uring-close-test
+/examples/io_uring-cp
+/examples/io_uring-test
+/examples/io_uring-udp
+/examples/link-cp
+/examples/napi-busy-poll-client
+/examples/napi-busy-poll-server
+/examples/ucontext-cp
+/examples/poll-bench
+/examples/proxy
+/examples/send-zerocopy
+/examples/rsrc-update-bench
+
+/test/*.t
+/test/*.dmesg
+/test/output/
+
+config-host.h
+config-host.mak
+config.log
+
+liburing.pc
+liburing-ffi.pc
+
+cscope.out

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 cmake-build-*/
 install
 bin
+lib
 *.d
 *.o
 *.o[ls]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,40 @@ MESSAGE(STATUS "UNIX: " ${UNIX})
 SET(IB_LANG "english")
 
 # Check for programs required to build InnoDB e.g., Bison and Flex
-FIND_PROGRAM(FLEX flex)
-FIND_PROGRAM(BISON bison)
+FIND_PROGRAM(FLEX flex REQUIRED)
+FIND_PROGRAM(BISON bison REQUIRED)
+
+# Include Flex and Bison CMake modules
+FIND_PACKAGE(FLEX REQUIRED)
+FIND_PACKAGE(BISON REQUIRED)
+
+# Debug output
+MESSAGE(STATUS "Flex executable: ${FLEX_EXECUTABLE}")
+
+# If flex include dir not found, try to find it manually
+if(NOT FLEX_INCLUDE_DIR)
+  # Try to find FlexLexer.h in common locations
+  find_path(FLEX_INCLUDE_DIR
+          NAMES FlexLexer.h
+          PATHS
+          /nix/store/*/include
+          /run/current-system/sw/include
+          ENV CPATH
+          PATH_SUFFIXES flex
+  )
+
+  if(NOT FLEX_INCLUDE_DIR)
+    message(FATAL_ERROR "Could not find FlexLexer.h. Please install flex development files.")
+  endif()
+endif()
+
+MESSAGE(STATUS "Flex include dir: ${FLEX_INCLUDE_DIR}")
+
+# Include flex directory
+INCLUDE_DIRECTORIES(${FLEX_INCLUDE_DIR})
+
+# Set up Flex/Bison generation
+FLEX_TARGET(Scanner pars/pars0lex.l ${CMAKE_CURRENT_BINARY_DIR}/lexyy.cc)
 
 INCLUDE(CheckTypeSize)
 

--- a/mem/mem0mem.cc
+++ b/mem/mem0mem.cc
@@ -242,7 +242,7 @@ mem_block_t *mem_heap_create_block(mem_heap_t *heap, ulint n, ulint type, Source
   /* In dynamic allocation, calculate the size: block header + data. */
 
   mem_block_t *block;
-  Buf_block *buf_block;
+  Buf_block *buf_block{};
 
   auto len = mem_block_header_size() + MEM_SPACE_NEEDED(n);
 


### PR DESCRIPTION
Add common ignores to a gitignore.
Add FlexLexer.h search; under NixOS couldn't get it to build without the search.
To get the build done `buf_block` must be initialized otherwise a code path will assign using an uninitialized variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Introduced a comprehensive `.gitignore` file to streamline version control by excluding unnecessary files and directories.
  
- **Build Configuration**
	- Enhanced the CMake build process by enforcing the presence of Flex and Bison, improving error handling, and adding debug output for better visibility.

- **Bug Fixes**
	- Updated the initialization of a memory block variable to prevent potential undefined behavior, ensuring it starts from a known state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->